### PR TITLE
Add statusline for agent container (#20)

### DIFF
--- a/containerize/Dockerfile
+++ b/containerize/Dockerfile
@@ -115,6 +115,10 @@ COPY mcp-config.json /etc/claude/mcp-config.json
 # Can be queried by startup script: podman run --rm $IMAGE cat /etc/freigang/mcp-manifest.json
 COPY mcp-manifest.json /etc/freigang/mcp-manifest.json
 
+# Statusline script for Claude Code TUI
+COPY agent-statusline.sh /usr/local/bin/agent-statusline.sh
+RUN chmod +x /usr/local/bin/agent-statusline.sh
+
 # Entrypoint script
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh

--- a/containerize/agent-statusline.sh
+++ b/containerize/agent-statusline.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Claude Code statusline for freigang agent container
+# Input: JSON from Claude Code via stdin
+# Output: formatted status string
+
+input=$(cat)
+
+cwd=$(echo "$input" | jq -r '.cwd // .workspace.current_dir // empty')
+model=$(echo "$input" | jq -r '.model.display_name // empty')
+ctx_used=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+cost=$(echo "$input" | jq -r '.session.total_cost_usd // empty')
+
+repo=""
+if [[ -n "$cwd" ]]; then
+    repo=$(echo "$cwd" | sed 's|^/workspace/||' | cut -d'/' -f1)
+fi
+
+out=""
+[[ -n "$repo" ]] && out="${repo}"
+out="${out} $(whoami)"
+[[ -n "$model" ]] && out="${out} | ${model}"
+[[ -n "$ctx_used" ]] && out="${out} | ctx:$(printf '%.0f' "$ctx_used")%"
+[[ -n "$cost" ]] && out="${out} | \$$(printf '%.4f' "$cost")"
+
+printf '%s' "$out"

--- a/containerize/entrypoint.sh
+++ b/containerize/entrypoint.sh
@@ -107,6 +107,20 @@ case "$BROWSER_MODE" in
         ;;
 esac
 
+# Initialize Claude settings with statusline on first run
+CLAUDE_SETTINGS="/workspace/.claude/settings.json"
+if [[ ! -f "$CLAUDE_SETTINGS" ]]; then
+    mkdir -p "$(dirname "$CLAUDE_SETTINGS")"
+    cat > "$CLAUDE_SETTINGS" <<'EOF'
+{
+  "statusLine": {
+    "type": "command",
+    "command": "bash /usr/local/bin/agent-statusline.sh"
+  }
+}
+EOF
+fi
+
 # Auto-sync repository if configured
 if [[ "$REPO_AUTO_SYNC" == "true" ]]; then
     echo "Auto-syncing repository: $REPO_NAME"


### PR DESCRIPTION
## Summary

- Add `containerize/agent-statusline.sh` baked into the image at `/usr/local/bin/agent-statusline.sh`
- `entrypoint.sh` initializes `/workspace/.claude/settings.json` on first run (skipped if the file already exists, preserving customizations)
- Statusline shows: repo (derived from cwd), user, model, context %, session cost

## Test plan

- [ ] Build image and start container; verify `/workspace/.claude/settings.json` is created with correct statusline config
- [ ] Confirm Claude Code TUI displays the statusline with all five fields
- [ ] Start a second time (settings.json already present) and verify the file is not overwritten

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)