### PR TITLE
Fix #30: inject CLAUDE_CODE_OAUTH_TOKEN into the container at launch

### DIFF
--- a/AGENT_ACCESS.md
+++ b/AGENT_ACCESS.md
@@ -18,7 +18,7 @@ You are running in an isolated container with restricted network access.
 - **mosquitto_sub** / **mosquitto_pub** - MQTT client tools for debugging brokers
 
 ### Credentials (environment variables)
-- `CLAUDE_CODE_OAUTH_TOKEN` - Long-lived Anthropic OAuth token (from `claude setup-token`) for Claude authentication; injected at launch so no interactive `/login` is needed
+- `CLAUDE_CODE_OAUTH_TOKEN` - Long-lived Anthropic OAuth token from `claude setup-token` (secret `.secrets/claude_setup_token`), injected at launch so no interactive `/login` is needed. Inference-only: it cannot establish Remote Control. For occasional Remote Control, run `claude-rc` inside the container (Tier-2) - it unsets this token and does a full-scope `claude auth login` first. See [docs/agent-auth-design.md](docs/agent-auth-design.md).
 - `GH_TOKEN` - GitHub personal access token for repo rhoerbe/hadmin
 - `HA_ACCESS_TOKEN` - Home Assistant long-lived access token
 - `MQTT_USER` - MQTT broker username

--- a/AGENT_ACCESS.md
+++ b/AGENT_ACCESS.md
@@ -18,6 +18,7 @@ You are running in an isolated container with restricted network access.
 - **mosquitto_sub** / **mosquitto_pub** - MQTT client tools for debugging brokers
 
 ### Credentials (environment variables)
+- `CLAUDE_CODE_OAUTH_TOKEN` - Long-lived Anthropic OAuth token (from `claude setup-token`) for Claude authentication; injected at launch so no interactive `/login` is needed
 - `GH_TOKEN` - GitHub personal access token for repo rhoerbe/hadmin
 - `HA_ACCESS_TOKEN` - Home Assistant long-lived access token
 - `MQTT_USER` - MQTT broker username

--- a/containerize/Dockerfile
+++ b/containerize/Dockerfile
@@ -119,5 +119,9 @@ COPY mcp-manifest.json /etc/freigang/mcp-manifest.json
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
+# Tier-2 Remote Control helper (see docs/agent-auth-design.md)
+COPY claude-rc /usr/local/bin/claude-rc
+RUN chmod +x /usr/local/bin/claude-rc
+
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["claude"]

--- a/containerize/claude-rc
+++ b/containerize/claude-rc
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Tier-2: occasional Remote Control from inside the agent container.
+#
+# Remote Control needs a *full-scope* claude.ai /login session token. The
+# baseline CLAUDE_CODE_OAUTH_TOKEN (a setup-token) is inference-only and, being
+# higher in Claude Code's auth precedence, shadows any /login. So unset it, log
+# in with a full-scope token (one-time; uses the paste-the-code flow in a
+# headless container), then start Remote Control.
+#
+# See docs/agent-auth-design.md (Tier 2). Requires Claude Code >= 2.1.51.
+set -euo pipefail
+
+unset CLAUDE_CODE_OAUTH_TOKEN
+
+if ! claude auth status 2>/dev/null | grep -q '"loggedIn": *true'; then
+    echo "No full-scope session yet - starting login."
+    echo "If the browser can't reach the callback (normal in a container), paste"
+    echo "the code shown in the browser back into this terminal when prompted."
+    claude auth login
+fi
+
+exec claude remote-control "$@"

--- a/containerize/test_inside_container.sh
+++ b/containerize/test_inside_container.sh
@@ -4,6 +4,7 @@ set -e
 
 echo "=== Environment ==="
 echo "HOME=$HOME"
+echo "CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN:+set (${#CLAUDE_CODE_OAUTH_TOKEN} chars)}"
 echo "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:+set (${#ANTHROPIC_API_KEY} chars)}"
 echo "GH_TOKEN=${GH_TOKEN:+set (${#GH_TOKEN} chars)}"
 echo "HTTP_PROXY=$HTTP_PROXY"

--- a/docs/agent-auth-design.md
+++ b/docs/agent-auth-design.md
@@ -131,19 +131,19 @@ refuse to launch — loudly — unless **all** hold:
   claude remote-control`.
 - Fix `AGENT_ACCESS.md`: the `CLAUDE_CODE_OAUTH_TOKEN` line should describe a `setup-token`
   (it currently does, but the implementation must match it).
-- Note the RC ≥ 2.1.51 requirement; update rainova from 2.1.30.
+- Note the RC ≥ 2.1.51 requirement (applies to Tier-2 only).
 
 ## Open questions / tests still to run
 
-1. **One token, many machines, concurrently?** Does a single `setup-token` authenticate the
-   container *and* a VM at the same time, or is one token-per-machine needed? (Decides
-   whether "single subscription, many agents" is one secret or many.)
+1. ✅ **One token, many machines, concurrently — VERIFIED** (2026-06-21, #32): a single
+   `CLAUDE_CODE_OAUTH_TOKEN` authenticated ray (2.1.176) and riva (2.1.185) with overlapping
+   `claude -p` calls — both exit 0, no 401. → baseline is **one shared setup-token** for the
+   fleet, not one per agent. Quota stays shared (see #4).
 2. **Does minting a new `setup-token` revoke a prior one?** (Verified: it does **not**
    invalidate the interactive `/login` session.)
 3. **rainova cross-machine kill** — when `/login` on riva apparently invalidated rainova:
    shared credential file, or an account-level grant cap? (Local evidence shows ≥2 `/login`
-   grants — r2h2 + ha_agent — coexisting, so a hard "1 device" cap is unlikely. rainova was
-   also below the RC version floor.)
+   grants — r2h2 + ha_agent — coexisting, so a hard "1 device" cap is unlikely.)
 4. **Pro quota** sufficiency for N concurrent agents; Max if not. (Parked tier decision.)
 5. **ray loose end:** `claude` is not installed for `agent` or `r2h2` on 10.2.2.50 — confirm
    which user/path ran the interactive `claude` that showed the onboarding picker.

--- a/docs/agent-auth-design.md
+++ b/docs/agent-auth-design.md
@@ -91,6 +91,26 @@ condition — `claude setup-token` works on 2.1.185.
 Also found: `.secrets/anthropic_api_key` is a 26-char `oauth-via-…` placeholder, not a real
 Console key.
 
+### Follow-up (2026-06-22): the missing-secret 401, and closing the validation gap
+
+After deploying the corrected launcher the container *still* 401'd. Cause:
+`.secrets/claude_setup_token` was never created, so the launcher fell back to the **stale
+legacy `.secrets/claude_oauth_token`** (a dead access token). Two fixes baked back in:
+
+- **Host-side validation was blind here.** `validate_claude_token` runs a live `claude -p`
+  probe, but the agent *host* has no `claude` (only the container image does), so it
+  reported "deferred" and the dead token reached the TUI. Now, when the host lacks `claude`,
+  the preflight probes **inside a throwaway container** (workspace mounted, mirroring the
+  real run's network/proxy). Only a *definitive* auth failure (401 / "invalid … credentials")
+  blocks launch; a network/other error just warns, to avoid false negatives.
+- **`--validate-auth`** is the reliable manual check: skips the TUI, runs an in-container
+  diagnostic (token presence, `claude auth status`, live `claude -p`), then exits.
+
+Verified 2026-06-22: a bogus token aborts the launch with exit 1 **before** the TUI; a valid
+token reports `oauth_token` and `claude -p → OK`. Also fixed a `deploy.sh` bug where the
+global `sed` rewrote the provenance sentinel in *two* places (variable + comparison),
+defeating drift detection — now it replaces only the anchored assignment lines.
+
 ## Per-environment plan
 
 | Environment | Mode | Baseline auth | Notes |
@@ -118,7 +138,8 @@ refuse to launch — loudly — unless **all** hold:
    auth status` only reports a token is *present* — a bogus token still shows
    `loggedIn:true` — so a real inference call (which 401s on a dead token) is the only
    reliable validator. (Implemented as `validate_claude_token` with a `SKIP_AUTH_PROBE=1`
-   opt-out.)
+   opt-out.) When the agent host has no `claude`, the probe runs inside a throwaway
+   container; `--validate-auth` runs the same check manually in-container.
 
 ## PR #31 — required corrections
 

--- a/docs/agent-auth-design.md
+++ b/docs/agent-auth-design.md
@@ -1,0 +1,156 @@
+# Agent Authentication Design — one subscription, many systems
+
+Status: **draft for review** · Date: 2026-06-21 · Context: issue #30, PR #31
+
+## Objective
+
+Run Claude Code **agents across many systems** — Win 11 notebook, WSL, Linux VMs, and
+rootless-Podman containers (the Freigang `*_agent` model) — all backed by **one Claude
+subscription** (currently **Pro**), without per-agent interactive `/login` babysitting,
+while **not precluding** occasional Remote Control of a session.
+
+## TL;DR — the decision
+
+Two tiers, chosen per agent:
+
+| Tier | For | Auth | Lifetime | Remote Control |
+|---|---|---|---|---|
+| **1 — Baseline** (default) | every headless / unattended / container agent | `CLAUDE_CODE_OAUTH_TOKEN` from `claude setup-token` | ~1 year | ❌ inference-only |
+| **2 — RC on demand** (opt-in, occasional) | a session you want to drive from phone/web | `unset CLAUDE_CODE_OAUTH_TOKEN` → `claude auth login` (full-scope) → `claude remote-control` | ~8 h, self-refreshing while running | ✅ |
+
+Rationale: subscription `/login` credentials are the *wrong primitive* for an
+**intermittently launched** headless agent — they assume a long-lived interactive session
+doing the token refresh; an idle container's credential simply rots (this is exactly how
+`ha_agent` died). A `setup-token` is idle-proof. Remote Control needs a *full-scope* login
+token, so it is handled as a deliberate, occasional switch rather than the baseline.
+
+## How Claude Code authentication actually works (verified 2026-06-21, CLI 2.1.185)
+
+### Credential precedence (Claude picks the first present)
+
+1. Cloud provider (Bedrock / Vertex / Foundry)
+2. `ANTHROPIC_AUTH_TOKEN` — Bearer; for LLM gateways/proxies
+3. `ANTHROPIC_API_KEY` — Console key; **metered**, sent as `x-api-key`
+4. `apiKeyHelper` — script returning a key (called on 401 / every 5 min)
+5. **`CLAUDE_CODE_OAUTH_TOKEN`** — long-lived token from `claude setup-token`
+6. **`/login`** subscription OAuth — the interactive default
+
+> Trap: #5 sits **above** #6. With the baseline env var set, an in-container `claude auth
+> login` is silently ignored and Remote Control fails with *"requires a full-scope login
+> token"*. Tier-2 **must** start by unsetting `CLAUDE_CODE_OAUTH_TOKEN`.
+
+### Token types vs capabilities
+
+| Token | Source | Lifetime | Inference | Remote Control |
+|---|---|---|---|---|
+| `/login` full-scope session | `claude` / `claude auth login` | ~8 h access + rotating single-use refresh; needs a live session to stay alive | ✅ | ✅ |
+| `setup-token` → `CLAUDE_CODE_OAUTH_TOKEN` | `claude setup-token` | ~1 year, no rotation | ✅ | ❌ (*"scoped to inference only"*) |
+| `ANTHROPIC_API_KEY` | Console (platform.claude.com) | static | ✅ (metered) | ❌ (*"API keys are not supported"*) |
+
+Remote Control requires CLI **≥ 2.1.51**, claude.ai OAuth, and is available on Pro.
+
+### Verified behaviours (the `claude auth status` oracle)
+
+`claude auth status` reports the active method non-interactively. On a throwaway
+`CLAUDE_CONFIG_DIR`:
+
+| Config state | `CLAUDE_CODE_OAUTH_TOKEN` | Result |
+|---|---|---|
+| fresh, no token | — | `loggedIn:false, authMethod:none` |
+| fresh, **not onboarded** | set | `loggedIn:true, authMethod:oauth_token` |
+| onboarded | set | `loggedIn:true, authMethod:oauth_token` |
+
+And `claude -p "…"`: fails with *"Not logged in · Please run /login"* without a token,
+returns a completion **with** the env token — on a fresh, never-logged-in config dir.
+
+**Conclusion:** the env token is **never ignored at the auth layer**. The "select a login
+method" screen seen on a fresh machine is the **interactive onboarding wizard** (shown when
+`.claude.json` is absent), not an auth failure. Remedies for fresh *interactive* machines:
+seed `.claude.json` with `hasCompletedOnboarding: true`, or run once to complete onboarding,
+or use `-p` (which skips onboarding entirely).
+
+## Post-mortem: why the container kept demanding `/login` (issue #30 / PR #31)
+
+Two independent breakages, both live on 2026-06-21:
+
+1. **PR #31 was never deployed.** Agents run as `sudo -iu ha_agent`, executing the
+   **deployed** `/home/ha_agent/start_container.sh` — dated **16 March**, with *no* token
+   injection. The PR's injection code exists only on branch `issue-30`; `deploy.sh` was not
+   re-run. So the container launched with **no Anthropic credential** and fell through to
+   `ha_agent`'s own `~/.claude/.credentials.json`, which had **expired 20 Jun 04:12** (a
+   `/login` token dead from idleness).
+2. **Wrong token type even if deployed.** The artifact the PR injects,
+   `.secrets/claude_oauth_token`, is **not** a `setup-token` — it is a **copied `/login`
+   access token** (`sk-ant-oat01-…`, 108 chars) written by the stopgap
+   `sync_oauth_token.sh`. Access tokens die in ~8 h, so it would 401 within hours anyway.
+
+PR #31's *description* (use `setup-token`) is correct; its *implementation* (copy an access
+token) is not. The "setup-token is broken" note in `sync_oauth_token.sh` was a February
+condition — `claude setup-token` works on 2.1.185.
+
+Also found: `.secrets/anthropic_api_key` is a 26-char `oauth-via-…` placeholder, not a real
+Console key.
+
+## Per-environment plan
+
+| Environment | Mode | Baseline auth | Notes |
+|---|---|---|---|
+| Containers (`*_agent`) | interactive `claude` (CMD), unattended | inject `CLAUDE_CODE_OAUTH_TOKEN` (setup-token) | onboarding already seeded (`hasCompletedOnboarding:true`); works once a *valid* token is injected |
+| Linux VMs (SSH'd) | headless `-p` or interactive | setup-token env var | callback server unreachable over SSH → never rely on interactive `/login` |
+| WSL | interactive or `-p` | setup-token env var | known callback-unreachable case |
+| Win 11 notebook | interactive (you sit here) | `/login` | the natural place to mint the setup-token and to run Tier-2 RC |
+| CI | `-p` | setup-token in CI secret | the canonical setup-token use case |
+
+All of the above draw from the **same shared subscription quota** (web + every agent). Pro
+is the smallest pool; a fleet of concurrent agents will hit rate limits before auth does.
+
+## Operational invariants the launcher/TUI must assert
+
+The issue #30 incident traces to silent drift. `start_container.sh` (and the TUI) should
+refuse to launch — loudly — unless **all** hold:
+
+1. **Run-as identity** = the agent user (the "User Mismatch" guard exists for YAML-config
+   mode; extend it to legacy mode too).
+2. **Deployed == source.** Stamp `git rev-parse HEAD` (or a version) into the script header
+   at `deploy.sh` time; compare against the repo at launch and warn on mismatch.
+3. **Credential is valid.** Preflight with a live `claude -p` probe and fail with a clear
+   message instead of dropping the agent at a `/login` it cannot complete. Note: `claude
+   auth status` only reports a token is *present* — a bogus token still shows
+   `loggedIn:true` — so a real inference call (which 401s on a dead token) is the only
+   reliable validator. (Implemented as `validate_claude_token` with a `SKIP_AUTH_PROBE=1`
+   opt-out.)
+
+## PR #31 — required corrections
+
+- Replace the access-token copy with a real **`setup-token`** secret
+  (`.secrets/claude_setup_token`); inject it as `CLAUDE_CODE_OAUTH_TOKEN`.
+- Demote/remove `sync_oauth_token.sh` (it can never enable Remote Control and expires in
+  hours); keep only as a documented emergency bridge, if at all.
+- Add the three launch invariants above.
+- Add a `claude-rc` helper for Tier-2: `unset CLAUDE_CODE_OAUTH_TOKEN; claude auth login;
+  claude remote-control`.
+- Fix `AGENT_ACCESS.md`: the `CLAUDE_CODE_OAUTH_TOKEN` line should describe a `setup-token`
+  (it currently does, but the implementation must match it).
+- Note the RC ≥ 2.1.51 requirement; update rainova from 2.1.30.
+
+## Open questions / tests still to run
+
+1. **One token, many machines, concurrently?** Does a single `setup-token` authenticate the
+   container *and* a VM at the same time, or is one token-per-machine needed? (Decides
+   whether "single subscription, many agents" is one secret or many.)
+2. **Does minting a new `setup-token` revoke a prior one?** (Verified: it does **not**
+   invalidate the interactive `/login` session.)
+3. **rainova cross-machine kill** — when `/login` on riva apparently invalidated rainova:
+   shared credential file, or an account-level grant cap? (Local evidence shows ≥2 `/login`
+   grants — r2h2 + ha_agent — coexisting, so a hard "1 device" cap is unlikely. rainova was
+   also below the RC version floor.)
+4. **Pro quota** sufficiency for N concurrent agents; Max if not. (Parked tier decision.)
+5. **ray loose end:** `claude` is not installed for `agent` or `r2h2` on 10.2.2.50 — confirm
+   which user/path ran the interactive `claude` that showed the onboarding picker.
+
+## References
+
+- Authentication — https://code.claude.com/docs/en/authentication
+- Remote Control — https://code.claude.com/docs/en/remote-control
+- Use Claude Code with Pro/Max — https://support.claude.com/en/articles/11145838
+- Related: [multi-agent-setup.md](multi-agent-setup.md), [../AGENT_ACCESS.md](../AGENT_ACCESS.md)

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -18,9 +18,11 @@ echo "Deploying scripts to $AGENT_HOME (version $COMMIT)..."
 
 # Scripts from scripts/
 sudo cp "$SCRIPT_DIR/start_container.sh" "$AGENT_HOME/"
+# Replace only the assignment lines (anchored) - a global match would also rewrite
+# the sentinel in show_deploy_provenance's comparison and defeat drift detection.
 sudo sed -i \
-    -e "s|__DEPLOYED_COMMIT__|$COMMIT|g" \
-    -e "s|__DEPLOYED_AT__|$DEPLOY_STAMP|g" \
+    -e "s|^DEPLOYED_COMMIT=.*|DEPLOYED_COMMIT=\"$COMMIT\"|" \
+    -e "s|^DEPLOYED_AT=.*|DEPLOYED_AT=\"$DEPLOY_STAMP\"|" \
     "$AGENT_HOME/start_container.sh"
 sudo cp "$SCRIPT_DIR/config.sh" "$AGENT_HOME/"
 sudo cp "$SCRIPT_DIR/launcher_tui.py" "$AGENT_HOME/"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -8,10 +8,20 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 AGENT_USER="ha_agent"
 AGENT_HOME="/home/$AGENT_USER"
 
-echo "Deploying scripts to $AGENT_HOME..."
+# Deploy provenance stamped into the deployed scripts (issue #30: a stale deploy
+# silently ran for months). Surfaced by start_container.sh at launch.
+COMMIT="$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+git -C "$REPO_ROOT" diff --quiet 2>/dev/null || COMMIT="${COMMIT}-dirty"
+DEPLOY_STAMP="$(date '+%Y-%m-%d %H:%M:%S')"
+
+echo "Deploying scripts to $AGENT_HOME (version $COMMIT)..."
 
 # Scripts from scripts/
 sudo cp "$SCRIPT_DIR/start_container.sh" "$AGENT_HOME/"
+sudo sed -i \
+    -e "s|__DEPLOYED_COMMIT__|$COMMIT|g" \
+    -e "s|__DEPLOYED_AT__|$DEPLOY_STAMP|g" \
+    "$AGENT_HOME/start_container.sh"
 sudo cp "$SCRIPT_DIR/config.sh" "$AGENT_HOME/"
 sudo cp "$SCRIPT_DIR/launcher_tui.py" "$AGENT_HOME/"
 

--- a/scripts/start_container.sh
+++ b/scripts/start_container.sh
@@ -521,26 +521,48 @@ validate_claude_token() {
     fi
     # Live probe: `claude auth status` only reports a token is *present*, not that
     # it works (a bogus token still shows loggedIn:true). A one-shot `claude -p`
-    # is the only real validator - it 401s on a dead/expired token. Skips when the
-    # host lacks the claude CLI (the container then validates at first call).
+    # is the only real validator - it 401s on a dead/expired token. Prefer the host
+    # CLI; if the agent host has no claude (common - only the container image does),
+    # probe inside a throwaway container that mirrors the real run's network/proxy.
+    # Only a *definitive* auth failure blocks launch; a network/other error warns,
+    # to avoid false negatives.
+    local out rc=0
     if command -v claude >/dev/null 2>&1; then
-        local tmpcfg out
-        tmpcfg=$(mktemp -d)
+        local tmpcfg; tmpcfg=$(mktemp -d)
         if out=$(CLAUDE_CODE_OAUTH_TOKEN="$CLAUDE_OAUTH_TOKEN" CLAUDE_CONFIG_DIR="$tmpcfg" \
-                 timeout 30 claude -p "reply with: OK" 2>&1); then
-            rm -rf "$tmpcfg"
-            echo "Anthropic auth: token validated (live inference probe)."
-        else
-            rm -rf "$tmpcfg"
-            echo "ERROR: Anthropic token failed a live auth probe:" >&2
-            echo "       ${out:-<no output>}" >&2
-            echo "       Refusing to launch with a dead credential. Mint a fresh one:" >&2
-            echo "         claude setup-token   (set SKIP_AUTH_PROBE=1 to bypass this check)" >&2
-            exit 1
-        fi
+                 timeout 30 claude -p "reply with: OK" 2>&1); then rc=0; else rc=$?; fi
+        rm -rf "$tmpcfg"
+    elif command -v podman >/dev/null 2>&1 && podman image exists "$CONTAINER_NAME" 2>/dev/null; then
+        echo "Anthropic auth: validating via container image $CONTAINER_NAME (no host claude)…"
+        if out=$(podman --cgroup-manager=cgroupfs run --rm \
+                    --userns=keep-id --network=ha-agent-net \
+                    -v "$AGENT_HOME/workspace":/workspace:Z \
+                    -e HTTP_PROXY=http://host.containers.internal:8888 \
+                    -e HTTPS_PROXY=http://host.containers.internal:8888 \
+                    -e NO_PROXY="api.anthropic.com,claude.ai,platform.claude.com,anthropic.com" \
+                    -e HOME=/workspace \
+                    -e CLAUDE_CODE_OAUTH_TOKEN="$CLAUDE_OAUTH_TOKEN" \
+                    "$CONTAINER_NAME" \
+                    bash -c 'export PATH=/usr/local/bin:/usr/bin:/bin:$PATH; claude -p "reply with: OK"' 2>&1)
+        then rc=0; else rc=$?; fi
     else
-        echo "Anthropic auth: token loaded; validation deferred ('claude' not on host PATH)."
+        echo "Anthropic auth: token loaded; validation skipped (no host claude, no podman/image)." >&2
+        return 0
     fi
+
+    if [[ $rc -eq 0 ]]; then
+        echo "Anthropic auth: token validated (live probe)."
+        return 0
+    fi
+    if grep -qiE '401|invalid (bearer|authentication|api)|not logged in|please run /login' <<<"$out"; then
+        echo "ERROR: Anthropic token failed authentication - refusing to launch:" >&2
+        echo "       ${out:-<no output>}" >&2
+        echo "       Mint a fresh token:  claude setup-token   (or SKIP_AUTH_PROBE=1 to bypass)" >&2
+        exit 1
+    fi
+    echo "WARNING: could not validate the token (looks like a network/other error, not an" >&2
+    echo "         auth failure); proceeding. Output: ${out:-<none>}" >&2
+    return 0
 }
 
 # Load secrets based on selection (populated after TUI runs, but need defaults for --quick mode)

--- a/scripts/start_container.sh
+++ b/scripts/start_container.sh
@@ -4,9 +4,10 @@
 #
 # Usage:
 #   start-ha-agent              # start Claude Code with TUI
-#   start-ha-agent --quick      # start Claude Code without TUI (use defaults)
-#   start-ha-agent --test       # run preflight and network connectivity tests
-#   start-ha-agent bash         # start bash shell
+#   start-ha-agent --quick         # start Claude Code without TUI (use defaults)
+#   start-ha-agent --validate-auth # skip TUI; run an in-container auth diagnostic and exit
+#   start-ha-agent --test          # run preflight and network connectivity tests
+#   start-ha-agent bash            # start bash shell
 #
 # MCP Server Configuration Flow (local scope - per project):
 #   1. Container has MCP manifest at /etc/freigang/mcp-manifest.json (installed servers)
@@ -240,12 +241,22 @@ SELECTED_BROWSER_MODE="none"
 SELECTED_ENABLE_VNC="false"
 SELECTED_WEB_RESOURCE_GROUPS=""
 SKIP_TUI=false
+VALIDATE_AUTH=false   # --validate-auth: skip TUI, run an in-container auth diagnostic
 
 # Parse initial arguments
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --quick)
             SKIP_TUI=true
+            shift
+            ;;
+        --validate-auth)
+            # Skip TUI, start with defaults, run an auth diagnostic in the
+            # container, then exit (no interactive claude). Skips the host-side
+            # probe so the in-container check always runs. See issue #30.
+            VALIDATE_AUTH=true
+            SKIP_TUI=true
+            export SKIP_AUTH_PROBE=1
             shift
             ;;
         --browser=*)
@@ -746,8 +757,34 @@ elif [[ -n "$AGENT_ID" && -n "$WEB_RESOURCES_PATH" && -f "$WEB_RESOURCES_PATH" ]
     WEB_RESOURCES_MOUNT="-v $WEB_RESOURCES_PATH:/etc/freigang/policies/${AGENT_ID}_web_resources.yaml:Z,ro"
 fi
 
-# Start container with Claude
-exec podman --cgroup-manager=cgroupfs run --rm -it \
+# Container command: normal interactive claude, or (--validate-auth) a one-shot
+# auth diagnostic that prints the injected token state and probes auth, then exits.
+TTY_FLAGS="-it"
+if [[ "$VALIDATE_AUTH" == true ]]; then
+    TTY_FLAGS="-i"
+    CONTAINER_CMD=(bash -c '
+export PATH="/usr/local/bin:/usr/bin:/bin:$PATH"
+echo "=== container auth diagnostic ==="
+echo "HOME=$HOME"
+echo "claude: $(command -v claude || echo NOT-FOUND)"
+if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+    echo "CLAUDE_CODE_OAUTH_TOKEN: set len=${#CLAUDE_CODE_OAUTH_TOKEN} prefix=$(printf %s "$CLAUDE_CODE_OAUTH_TOKEN" | cut -c1-13)"
+else
+    echo "CLAUDE_CODE_OAUTH_TOKEN: EMPTY (nothing injected)"
+fi
+echo "ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:+set}"
+echo "-- persisted /login creds (would override an empty token) --"
+ls -la "$HOME/.claude/.credentials.json" 2>/dev/null || echo "(none)"
+echo "-- claude --version --"; claude --version
+echo "-- claude auth status --"; claude auth status 2>&1 | head
+echo "-- claude -p live probe --"; claude -p "reply with: OK" 2>&1 | head
+')
+else
+    CONTAINER_CMD=(claude $CLAUDE_ARGS)
+fi
+
+# Start container
+exec podman --cgroup-manager=cgroupfs run --rm $TTY_FLAGS \
     --name "$CONTAINER_NAME" \
     --userns=keep-id \
     --shm-size=2g \
@@ -772,4 +809,4 @@ exec podman --cgroup-manager=cgroupfs run --rm -it \
     -e MQTT_USER="$MQTT_USER" \
     -e MQTT_PASS="$MQTT_PASS" \
     "$CONTAINER_NAME" \
-    claude $CLAUDE_ARGS
+    "${CONTAINER_CMD[@]}"

--- a/scripts/start_container.sh
+++ b/scripts/start_container.sh
@@ -24,6 +24,12 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Deploy provenance — rewritten by deploy.sh when the script is copied to an
+# agent home. Running from the source tree leaves the sentinels in place. Shown
+# at launch so a stale deployment (root cause of issue #30) is visible, not silent.
+DEPLOYED_COMMIT="__DEPLOYED_COMMIT__"
+DEPLOYED_AT="__DEPLOYED_AT__"
+
 # ============================================================================
 # Agent Selection Functions
 # ============================================================================
@@ -134,6 +140,16 @@ validate_agent_user() {
     fi
 }
 
+show_deploy_provenance() {
+    # Make deployment staleness visible (issue #30: the agent silently ran a
+    # months-old deployed copy). deploy.sh stamps the commit/date into the copy.
+    if [[ "$DEPLOYED_COMMIT" == "__DEPLOYED_COMMIT__" ]]; then
+        echo "start_container.sh: running from source tree (not a deployed copy)"
+    else
+        echo "start_container.sh: deployed from commit $DEPLOYED_COMMIT on $DEPLOYED_AT"
+    fi
+}
+
 # ============================================================================
 # Main Initialization
 # ============================================================================
@@ -183,6 +199,8 @@ else
         exec sudo -iu "$AGENT_USER" "$AGENT_HOME/start_container.sh" "$@"
     fi
 fi
+
+show_deploy_provenance
 
 # Derive web access filter paths (set after agent config is loaded)
 WEB_RESOURCES_PATH=""
@@ -478,22 +496,69 @@ is_secret_selected() {
     return 1
 }
 
+# Preflight the injected Anthropic token so a dead/expired credential fails loudly
+# here, instead of dropping the agent at an interactive /login it cannot complete
+# (issue #30). Best-effort: only fully validated when the host has the claude CLI.
+validate_claude_token() {
+    [[ -z "$CLAUDE_OAUTH_TOKEN" ]] && return 0   # missing token already warned about
+    if [[ "$CLAUDE_OAUTH_TOKEN" != sk-ant-* ]]; then
+        echo "WARNING: Anthropic token has an unexpected format (expected 'sk-ant-…')." >&2
+    fi
+    if [[ "${SKIP_AUTH_PROBE:-0}" == "1" ]]; then
+        echo "Anthropic auth: live probe skipped (SKIP_AUTH_PROBE=1)."
+        return 0
+    fi
+    # Live probe: `claude auth status` only reports a token is *present*, not that
+    # it works (a bogus token still shows loggedIn:true). A one-shot `claude -p`
+    # is the only real validator - it 401s on a dead/expired token. Skips when the
+    # host lacks the claude CLI (the container then validates at first call).
+    if command -v claude >/dev/null 2>&1; then
+        local tmpcfg out
+        tmpcfg=$(mktemp -d)
+        if out=$(CLAUDE_CODE_OAUTH_TOKEN="$CLAUDE_OAUTH_TOKEN" CLAUDE_CONFIG_DIR="$tmpcfg" \
+                 timeout 30 claude -p "reply with: OK" 2>&1); then
+            rm -rf "$tmpcfg"
+            echo "Anthropic auth: token validated (live inference probe)."
+        else
+            rm -rf "$tmpcfg"
+            echo "ERROR: Anthropic token failed a live auth probe:" >&2
+            echo "       ${out:-<no output>}" >&2
+            echo "       Refusing to launch with a dead credential. Mint a fresh one:" >&2
+            echo "         claude setup-token   (set SKIP_AUTH_PROBE=1 to bypass this check)" >&2
+            exit 1
+        fi
+    else
+        echo "Anthropic auth: token loaded; validation deferred ('claude' not on host PATH)."
+    fi
+}
+
 # Load secrets based on selection (populated after TUI runs, but need defaults for --quick mode)
 load_selected_secrets() {
-    # Anthropic auth - always injected (not user-selectable): without it Claude
-    # Code cannot authenticate and falls back to an interactive /login that is
-    # impossible in the headless container. Use a long-lived token minted with
-    # `claude setup-token` so it is independent of the host session's rotating
-    # OAuth refresh token (see CLAUDE_CODE_OAUTH_TOKEN below).
+    # Anthropic auth (Tier-1 baseline) - always injected, not user-selectable.
+    # Without a credential Claude Code falls back to interactive /login, which is
+    # impossible in the headless container. Inject a long-lived token minted with
+    # `claude setup-token` (CLAUDE_CODE_OAUTH_TOKEN): ~1y, no refresh rotation, so
+    # it is idle-proof - unlike a copied /login access token, which dies in ~8h.
+    # This token is inference-only and cannot do Remote Control; for that use the
+    # in-container `claude-rc` helper (Tier-2), which unsets this var first.
     CLAUDE_OAUTH_TOKEN=""
-    if [[ -f "$AGENT_HOME/workspace/.secrets/claude_oauth_token" ]]; then
-        CLAUDE_OAUTH_TOKEN=$(cat "$AGENT_HOME/workspace/.secrets/claude_oauth_token")
+    local setup_token="$AGENT_HOME/workspace/.secrets/claude_setup_token"
+    local legacy_token="$AGENT_HOME/workspace/.secrets/claude_oauth_token"
+    if [[ -f "$setup_token" ]]; then
+        CLAUDE_OAUTH_TOKEN=$(cat "$setup_token")
+    elif [[ -f "$legacy_token" ]]; then
+        CLAUDE_OAUTH_TOKEN=$(cat "$legacy_token")
+        echo "WARNING: using legacy secret $legacy_token - this is likely a short-lived" >&2
+        echo "         access token (deprecated sync_oauth_token.sh) that 401s in ~8h." >&2
+        echo "         Replace it with a durable token:  claude setup-token  then" >&2
+        echo "         install -m600 /dev/stdin $setup_token <<<'<token>'" >&2
     else
-        echo "WARNING: $AGENT_HOME/workspace/.secrets/claude_oauth_token not found." >&2
-        echo "         Claude will likely 401 and prompt for /login. Create it with:" >&2
+        echo "WARNING: no Anthropic token found at $setup_token" >&2
+        echo "         Claude will 401 and prompt for /login. Create it with:" >&2
         echo "           claude setup-token   # on the host, then:" >&2
-        echo "           install -m600 /dev/stdin $AGENT_HOME/workspace/.secrets/claude_oauth_token <<<'<token>'" >&2
+        echo "           install -m600 /dev/stdin $setup_token <<<'<token>'" >&2
     fi
+    validate_claude_token
 
     # Selectable secrets - only loaded if selected in TUI
     GH_TOKEN=""

--- a/scripts/start_container.sh
+++ b/scripts/start_container.sh
@@ -480,6 +480,21 @@ is_secret_selected() {
 
 # Load secrets based on selection (populated after TUI runs, but need defaults for --quick mode)
 load_selected_secrets() {
+    # Anthropic auth - always injected (not user-selectable): without it Claude
+    # Code cannot authenticate and falls back to an interactive /login that is
+    # impossible in the headless container. Use a long-lived token minted with
+    # `claude setup-token` so it is independent of the host session's rotating
+    # OAuth refresh token (see CLAUDE_CODE_OAUTH_TOKEN below).
+    CLAUDE_OAUTH_TOKEN=""
+    if [[ -f "$AGENT_HOME/workspace/.secrets/claude_oauth_token" ]]; then
+        CLAUDE_OAUTH_TOKEN=$(cat "$AGENT_HOME/workspace/.secrets/claude_oauth_token")
+    else
+        echo "WARNING: $AGENT_HOME/workspace/.secrets/claude_oauth_token not found." >&2
+        echo "         Claude will likely 401 and prompt for /login. Create it with:" >&2
+        echo "           claude setup-token   # on the host, then:" >&2
+        echo "           install -m600 /dev/stdin $AGENT_HOME/workspace/.secrets/claude_oauth_token <<<'<token>'" >&2
+    fi
+
     # Selectable secrets - only loaded if selected in TUI
     GH_TOKEN=""
     HA_ACCESS_TOKEN=""
@@ -548,6 +563,7 @@ if [[ $# -gt 0 && "$1" != "--"* ]]; then
         -e HTTPS_PROXY=http://host.containers.internal:8888 \
         -e NO_PROXY="api.anthropic.com,claude.ai,platform.claude.com,anthropic.com" \
         -e HOME=/workspace \
+        -e CLAUDE_CODE_OAUTH_TOKEN="$CLAUDE_OAUTH_TOKEN" \
         -e BROWSER_MODE="$SELECTED_BROWSER_MODE" \
         -e ENABLE_VNC="$SELECTED_ENABLE_VNC" \
         -e GH_TOKEN="$GH_TOKEN" \
@@ -681,6 +697,7 @@ exec podman --cgroup-manager=cgroupfs run --rm -it \
     -e HTTPS_PROXY=http://host.containers.internal:8888 \
     -e NO_PROXY="api.anthropic.com,claude.ai,platform.claude.com,anthropic.com" \
     -e HOME=/workspace \
+    -e CLAUDE_CODE_OAUTH_TOKEN="$CLAUDE_OAUTH_TOKEN" \
     -e BROWSER_MODE="$SELECTED_BROWSER_MODE" \
     -e ENABLE_VNC="$SELECTED_ENABLE_VNC" \
     -e REPO_AUTO_SYNC="${REPO_AUTO_SYNC:-false}" \

--- a/scripts/sync_oauth_token.sh
+++ b/scripts/sync_oauth_token.sh
@@ -1,16 +1,15 @@
 #!/bin/bash
-# Short-term bridge for container Claude auth (see issue #30).
+# DEPRECATED emergency bridge (see issue #30 and docs/agent-auth-design.md).
 #
-# `claude setup-token` (the durable long-lived token minter) is currently broken
-# against Anthropic's new OAuth endpoints. As a stopgap, copy the *host* user's
-# current Claude access token into the agent secret that start_container.sh
-# injects as CLAUDE_CODE_OAUTH_TOKEN.
-#
-# Run this as the logged-in host user (the one with a working /login) BEFORE
-# launching the container. The access token is valid until its expiry (a few
-# hours) regardless of the host session's refresh-token rotation, so re-run this
-# whenever the container starts failing with 401. Replace with setup-token once
-# that flow works again.
+# Prefer `claude setup-token`, which mints a durable (~1y) token and works on the
+# current CLI - it was only briefly broken in Feb 2026. This script instead
+# copies the host user's short-lived /login *access token* into the agent secret
+# that start_container.sh injects as CLAUDE_CODE_OAUTH_TOKEN. That access token:
+#   * expires in ~8h, so you must re-run this whenever the container 401s, and
+#   * is inference-only when delivered via env var - it can NEVER do Remote
+#     Control (which needs a full-scope /login; see claude-rc / Tier-2).
+# Use only as a last resort when you cannot mint a setup-token. It writes the
+# legacy secret name, which start_container.sh accepts with a warning.
 set -euo pipefail
 
 SRC="${CLAUDE_CREDENTIALS:-$HOME/.claude/.credentials.json}"

--- a/scripts/sync_oauth_token.sh
+++ b/scripts/sync_oauth_token.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Short-term bridge for container Claude auth (see issue #30).
+#
+# `claude setup-token` (the durable long-lived token minter) is currently broken
+# against Anthropic's new OAuth endpoints. As a stopgap, copy the *host* user's
+# current Claude access token into the agent secret that start_container.sh
+# injects as CLAUDE_CODE_OAUTH_TOKEN.
+#
+# Run this as the logged-in host user (the one with a working /login) BEFORE
+# launching the container. The access token is valid until its expiry (a few
+# hours) regardless of the host session's refresh-token rotation, so re-run this
+# whenever the container starts failing with 401. Replace with setup-token once
+# that flow works again.
+set -euo pipefail
+
+SRC="${CLAUDE_CREDENTIALS:-$HOME/.claude/.credentials.json}"
+AGENT_USER="${AGENT_USER:-ha_agent}"
+AGENT_HOME="${AGENT_HOME:-/home/$AGENT_USER}"
+DEST="$AGENT_HOME/workspace/.secrets/claude_oauth_token"
+
+if [[ ! -f "$SRC" ]]; then
+    echo "ERROR: $SRC not found - log in on the host with /login first." >&2
+    exit 1
+fi
+
+token=$(jq -r '.claudeAiOauth.accessToken // empty' "$SRC")
+if [[ -z "$token" ]]; then
+    echo "ERROR: no claudeAiOauth.accessToken in $SRC" >&2
+    exit 1
+fi
+
+exp=$(jq -r '.claudeAiOauth.expiresAt // 0' "$SRC")
+now=$(( $(date +%s) * 1000 ))
+if (( exp > 0 && exp < now )); then
+    echo "WARNING: host access token already expired ($(date -d @$((exp/1000))))." >&2
+    echo "         Let your host Claude session refresh (or run /login), then re-run." >&2
+fi
+
+printf '%s' "$token" | sudo install -o "$AGENT_USER" -g "$AGENT_USER" -m600 /dev/stdin "$DEST"
+echo "Wrote $DEST"
+if (( exp > 0 )); then
+    echo "Token valid until: $(date -d @$((exp/1000)))"
+fi


### PR DESCRIPTION
## Problem
The containerized agent demanded `/login` (impossible headless). Root cause was **two
independent failures**:
1. **PR not deployed** — agents run as `sudo -iu ha_agent`, executing the *deployed*
   `/home/ha_agent/start_container.sh` (months old). The injection code lived only on
   this branch; `deploy.sh` was never re-run, so nothing was injected.
2. **Wrong token type** — the injected secret was a copied `/login` *access token*
   (~8h life) from the stopgap `sync_oauth_token.sh`, **not** a durable `setup-token`,
   so it would 401 within hours even once deployed.

See `docs/agent-auth-design.md` for the full post-mortem and the two-tier auth model.

## Fix
- `start_container.sh`: inject `CLAUDE_CODE_OAUTH_TOKEN` from a real `setup-token`
  secret `.secrets/claude_setup_token` (~1y, idle-proof). Legacy `claude_oauth_token`
  is still read as a fallback with a deprecation warning.
- `validate_claude_token`: live `claude -p` preflight (with `SKIP_AUTH_PROBE=1`
  opt-out) — a dead token fails loudly here instead of dropping the agent at an
  impossible `/login`. (`claude auth status` only reports *presence*, not validity.)
- Deploy-drift guard: `deploy.sh` stamps commit+date into the deployed script;
  `start_container.sh` prints it at launch so a stale deployment is visible.
- `claude-rc` (shipped in the image): Tier-2 Remote Control helper — unsets the
  token, does a full-scope `claude auth login`, then `claude remote-control`.
  (Remote Control requires a full-scope `/login`; setup-token is inference-only.)
- `sync_oauth_token.sh`: marked DEPRECATED emergency bridge.
- Docs: `docs/agent-auth-design.md`, `AGENT_ACCESS.md`.

## Operator setup (one-time)
```bash
claude setup-token        # on the host; complete login, copy the token
install -m600 /dev/stdin /home/ha_agent/workspace/.secrets/claude_setup_token <<<'<token>'
./scripts/deploy.sh       # IMPORTANT: redeploy so ha_agent runs the new script
```

## Follow-ups
Open questions tracked as sub-issues of #30: #32 (one token, many machines),
#33 (setup-token coexistence), #34 (cross-machine /login invalidation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)